### PR TITLE
Update link for gtdbtk_r207_v2_data.tar.gz for faster downloads

### DIFF
--- a/backends/hpc/README.md
+++ b/backends/hpc/README.md
@@ -41,7 +41,7 @@ The pipeline requires two publicly licensed reference databases, [UniRef100](htt
 
 # make a directory for and download the reference databases
 mkdir dataset; cd dataset
-wget https://data.gtdb.ecogenomic.org/releases/release207/207.0/auxillary_files/gtdbtk_r207_v2_data.tar.gz
+wget https://data.ace.uq.edu.au/public/gtdb/data/releases/release207/207.0/auxillary_files/gtdbtk_r207_v2_data.tar.gz
 wget https://zenodo.org/records/4626519/files/uniref100.KO.v1.dmnd.gz
 gunzip uniref100.KO.v1.dmnd.gz
 


### PR DESCRIPTION
Previous link resulted in remarkably slow download speeds – topping out at 400kb/s. Which means this file takes literal days to download (if at all).

This appears to be a known issue. See Ecogenomics/GTDBTk#522.

Changing the wget command to download from the mirror which seems to have much more stable and faster download speeds – 11.4 MB/s for me.